### PR TITLE
Support remote ollama

### DIFF
--- a/Ollama/Ollama/Info.plist
+++ b/Ollama/Ollama/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>

--- a/Ollama/Ollama/Router.swift
+++ b/Ollama/Ollama/Router.swift
@@ -18,11 +18,11 @@ struct Router {
 	let session: URLSession = .shared
 	let decoder: JSONDecoder = .init()
 	
-	init(endpoint: Endoint = .chat) {
+	init(endpoint: Endpoint = .chat) {
 		self.path = endpoint.rawValue
 	}
 	
-	enum Endoint: String {
+	enum Endpoint: String {
 		case chat = "/api/chat"
 		case generate = "/api/generate"
 	}

--- a/Workflow/src/info.plist
+++ b/Workflow/src/info.plist
@@ -2037,7 +2037,7 @@ killall ollama</string>
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>curl -s http://localhost:${workflow_port}/api/generate -d "{\"model\": \"$1\", \"keep_alive\": 0}"</string>
+				<string>curl -s http://${workflow_host}:${workflow_port}/api/generate -d "{\"model\": \"$1\", \"keep_alive\": 0}"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>

--- a/Workflow/src/ollama.sh
+++ b/Workflow/src/ollama.sh
@@ -13,7 +13,14 @@ update_models() {
     fi
 }
 
-[[ -z $(lsof -nP -i4TCP:${workflow_port}) ]] || is_ollama_running=true
+# Set the OLLAMA_HOST environment variable
+export OLLAMA_HOST=http://${workflow_host:-localhost}:${workflow_port:-11434}
+
+# Check if ollama is running using the `ollama --version` command
+if ! ollama --version | grep -q "could not connect to a running Ollama instance"; then
+    is_ollama_running=true
+fi
+
 [[ -d ${alfred_workflow_cache} ]] || /bin/mkdir -p "${alfred_workflow_cache}"
 [[ -f ${model_json} ]] || update_models
 


### PR DESCRIPTION
This PR adds support for remote Ollama through the following changes:

1. First-class support of workflow_host and workflow_port, including detecting if Ollama is running
2. Fixing App Transport Security for the Swift CLI project